### PR TITLE
Handle torch deprecations of `torch.cuda.amp`

### DIFF
--- a/src/mamba2_torch/ops/custom_fwd_bwd.py
+++ b/src/mamba2_torch/ops/custom_fwd_bwd.py
@@ -1,0 +1,18 @@
+import torch
+
+
+def custom_amp_decorator(dec, cuda_amp_deprecated):
+    def decorator(func):
+        return dec(func) if not cuda_amp_deprecated else dec(func, device_type="cuda")
+    return decorator
+
+
+if hasattr(torch.cuda.amp, "custom_fwd"):
+    deprecated = False
+    from torch.cuda.amp import custom_fwd, custom_bwd
+else:
+    deprecated = True
+    from torch.amp import custom_fwd, custom_bwd
+
+custom_fwd = custom_amp_decorator(custom_fwd, deprecated)
+custom_bwd = custom_amp_decorator(custom_bwd, deprecated)

--- a/src/mamba2_torch/ops/layer_norm.py
+++ b/src/mamba2_torch/ops/layer_norm.py
@@ -11,10 +11,10 @@ import warnings
 
 import torch
 import torch.nn.functional as F
-from torch.cuda.amp import custom_fwd, custom_bwd
-
 import triton
 import triton.language as tl
+
+from ..ops.custom_fwd_bwd import custom_fwd, custom_bwd
 
 
 def layer_norm_ref(

--- a/src/mamba2_torch/ops/ssd_combined.py
+++ b/src/mamba2_torch/ops/ssd_combined.py
@@ -10,9 +10,6 @@ from packaging import version
 
 import torch
 import torch.nn.functional as F
-from torch import Tensor
-from torch.cuda.amp import custom_bwd, custom_fwd
-
 import triton
 import triton.language as tl
 
@@ -38,6 +35,7 @@ from ..ops.ssd_chunk_scan import chunk_scan, chunk_scan_ref
 from ..ops.ssd_chunk_scan import _chunk_scan_bwd_ddAcs_prev
 from ..ops.layernorm_gated import rmsnorm_fn, _layer_norm_fwd, _layer_norm_bwd
 from ..ops.k_activations import _swiglu_fwd, _swiglu_bwd
+from ..ops.custom_fwd_bwd import custom_bwd, custom_fwd
 
 TRITON_22 = version.parse(triton.__version__) >= version.parse('2.2.0')
 


### PR DESCRIPTION
Newer torch versions (2.4+) changed the import structure and how `custom_fwd/bwd` is handled. This PR adds custom logic to keep it compatible with newer versions while keeping it BC.

P.S. The requirements.txt has pinned versions so you should not have encountered these issues except you changed the versions yourself.