### PR TITLE
Fix batched generation which is dependent on left padding - BREAKING! :face_exhaling:

### DIFF
--- a/tests/Test.py
+++ b/tests/Test.py
@@ -12,8 +12,9 @@ config.use_triton_kernels = False
 
 model = Mamba2ForCausalLM.from_pretrained(mamba2_hf_path, config=config, local_files_only=True).to(device, dtype=dtype)
 tokenizer = AutoTokenizer.from_pretrained(mamba2_hf_path, local_files_only=True)
+tokenizer.padding_side = "left"
 
-input_ids = tokenizer(["Hey how are you doing?", "What is life?"], padding=True, return_tensors="pt")["input_ids"].to(device)
+input_ids = tokenizer(["Hey how are you doing?", "What is life?"], padding=True, return_tensors="pt").to(device)
 
-out = model.generate(input_ids, max_new_tokens=10, use_cache=True)
+out = model.generate(**input_ids, max_new_tokens=10, use_cache=True)
 print(tokenizer.batch_decode(out))

--- a/tests/TestSSDMinimal.py
+++ b/tests/TestSSDMinimal.py
@@ -34,3 +34,17 @@ y_min_2, _ = ssd_minimal_discrete(x, dt, A, B, C, chunk_size, D=None, initial_st
 print(torch.allclose(l, l_min, atol=0.01, rtol=0.01))
 print(torch.allclose(y, y_min, atol=0.01, rtol=0.01))
 print(torch.allclose(y_2, y_min_2, atol=0.01, rtol=0.01))
+
+
+# very messy lmao
+t = 50
+y1, l1 = mamba_chunk_scan_combined(x[:, :t, :, :], dt[:, :t, :], A, B[:, :t, :, :], C[:, :t, :, :], chunk_size, D=D, initial_states=initial_state, return_final_states=True)
+
+attention_mask = torch.ones(size=(batch, seqlen)).to(device, dtype=torch.int64)
+attention_mask[:, t:] = 0
+attention_mask_1 = attention_mask[:, :, None]
+attention_mask_2 = attention_mask[:, :, None, None]
+y2, l2 = mamba_chunk_scan_combined(x * attention_mask_2, dt * attention_mask_1, A, B * attention_mask_2, C * attention_mask_2, chunk_size, D=D, initial_states=initial_state, return_final_states=True)
+
+print(torch.allclose(y1, y2[:, :t, :], atol=0.01, rtol=0.01))
+print(torch.allclose(l1, l2, atol=0.01, rtol=0.01))


### PR DESCRIPTION
I will probably not merge this PR but keep it as is. It fixes a huge issue within mamba-related models: Generation with padding. This is due to the fact that the eos token is used as pad token which results in unwanted repeated influence of it. 

This fix requires the tokenizer to be left padding. But, for right padding, there is an interesting use case to enable correct last ssm states even with padding. See the tests...